### PR TITLE
request parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ ADD_EXECUTABLE(bench_queue_flood
 
 ADD_EXECUTABLE(test
                tests/queue
+               tests/request
                tests/main
                )
 

--- a/include/darner/request.hpp
+++ b/include/darner/request.hpp
@@ -42,7 +42,7 @@ struct request_grammar : boost::spirit::qi::grammar<Iterator>
       using namespace boost;
 
       key_name =
-         +((qi::alnum|qi::punct) - '/') [_val += qi::_1];
+         +((qi::alnum|qi::punct) - '/');
 
       stats =
          lit("STATS")     [phoenix::ref(req_.type) = request::RT_STATS];

--- a/include/darner/request.hpp
+++ b/include/darner/request.hpp
@@ -1,0 +1,101 @@
+#ifndef __DARNER_REQUEST_HPP__
+#define __DARNER_REQUEST_HPP__
+
+#include <string>
+
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/phoenix_core.hpp>
+#include <boost/spirit/include/phoenix_operator.hpp>
+
+namespace darner {
+
+struct request
+{
+   enum request_type
+   {
+      RT_STATS     = 1,
+      RT_VERSION   = 2,
+      RT_FLUSH     = 3,
+      RT_FLUSH_ALL = 4,
+      RT_DELETE    = 5,
+      RT_SET       = 6,
+      RT_GET       = 7
+   };
+
+   request_type type;
+   std::string queue;
+   size_t num_bytes;
+   bool get_open;
+   bool get_close;
+   bool get_abort;
+   size_t wait_ms;
+};
+
+template <class Iterator>
+struct request_grammar : boost::spirit::qi::grammar<Iterator>
+{
+   request_grammar(request& req)
+   : request_grammar::base_type(start),
+     req_(req)
+   {
+      using namespace boost::spirit;
+      using namespace boost;
+
+      key_name =
+         +((qi::alnum|qi::punct) - '/') [_val += qi::_1];
+
+      stats =
+         lit("STATS")     [phoenix::ref(req_.type) = request::RT_STATS];
+
+      version =
+         lit("VERSION")   [phoenix::ref(req_.type) = request::RT_VERSION];
+
+      flush =
+         lit("FLUSH ")    [phoenix::ref(req_.type) = request::RT_FLUSH]
+         >> key_name      [phoenix::ref(req_.queue) = qi::_1];
+
+      flush_all =
+         lit("FLUSH_ALL") [phoenix::ref(req_.type) = request::RT_FLUSH_ALL];
+
+      set =
+         lit("SET ")      [phoenix::ref(req_.type) = request::RT_SET]
+         >> key_name      [phoenix::ref(req_.queue) = qi::_1]
+         >> ' '
+         >> qi::uint_     [phoenix::ref(req_.num_bytes) = qi::_1];
+
+      get_option =
+         lit("/open")     [phoenix::ref(req_.get_open) = true]
+         | lit("/close")  [phoenix::ref(req_.get_close) = true]
+         | lit("/abort")  [phoenix::ref(req_.get_abort) = true]
+         | (
+            lit("/t=")
+            >> qi::uint_  [phoenix::ref(req_.wait_ms) = qi::_1]
+           );
+
+      get = lit("GET ")   [phoenix::ref(req_.type) = request::RT_GET]
+         >> key_name      [phoenix::ref(req_.queue) = qi::_1]
+         >> *get_option;
+
+      start = (stats | version | flush | flush_all | set | get) >> qi::eol;
+   }
+
+   bool parse(Iterator begin, Iterator end)
+   {
+      new(&req_) request(); // spooky placement new!
+      return boost::spirit::qi::parse(begin, end, *this) && (begin == end);
+   }
+
+   template <class Sequence>
+   bool parse(const Sequence& seq)
+   {
+      return parse(seq.begin(), seq.end());
+   }
+
+   request& req_;
+   boost::spirit::qi::rule<Iterator, std::string()> key_name;
+   boost::spirit::qi::rule<Iterator> stats, version, flush, flush_all, set, get_option, get, start;
+};
+
+} // darner
+
+#endif // __DARNER_REQUEST_HPP__

--- a/tests/fixtures/basic_request.hpp
+++ b/tests/fixtures/basic_request.hpp
@@ -1,0 +1,26 @@
+#ifndef __TESTS_FIXTURES_BASIC_REQUEST_HPP__
+#define __TESTS_FIXTURES_BASIC_REQUEST_HPP__
+
+#include "darner/request.hpp"
+
+namespace fixtures {
+
+// create a single basic request object
+class basic_request
+{
+public:
+
+   basic_request()
+   : grammar_(request_)
+   {
+   }
+
+protected:
+
+   darner::request request_;
+   darner::request_grammar<std::string::const_iterator> grammar_;
+};
+
+} // fixtures
+
+#endif // __TESTS_FIXTURES_BASIC_REQUEST_HPP__

--- a/tests/request.cpp
+++ b/tests/request.cpp
@@ -1,0 +1,58 @@
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include <string>
+
+#include "darner/request.hpp"
+#include "fixtures/basic_request.hpp"
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE( request_tests )
+
+// test we read stats correctly
+BOOST_FIXTURE_TEST_CASE( test_stats, fixtures::basic_request )
+{
+   BOOST_REQUIRE(grammar_.parse(string("STATS\r\n")));
+   BOOST_REQUIRE_EQUAL(request_.type, darner::request::RT_STATS);
+}
+
+// test that we get the queue name for a flush command correctly
+BOOST_FIXTURE_TEST_CASE( test_flush, fixtures::basic_request )
+{
+   BOOST_REQUIRE(grammar_.parse(string("FLUSH foo+meow\r\n")));
+   BOOST_REQUIRE_EQUAL(request_.type, darner::request::RT_FLUSH);
+   BOOST_REQUIRE_EQUAL(request_.queue, "foo+meow");
+}
+
+// test that we get the num bytes for a set correctly
+BOOST_FIXTURE_TEST_CASE( test_set, fixtures::basic_request )
+{
+   BOOST_REQUIRE(grammar_.parse(string("SET foo+meow 31337\r\n")));
+   BOOST_REQUIRE_EQUAL(request_.type, darner::request::RT_SET);
+   BOOST_REQUIRE_EQUAL(request_.queue, "foo+meow");
+   BOOST_REQUIRE_EQUAL(request_.num_bytes, 31337);
+}
+
+// test that we get some options correctly for a get
+BOOST_FIXTURE_TEST_CASE( test_get, fixtures::basic_request )
+{
+   BOOST_REQUIRE(grammar_.parse(string("GET foo+meow/t=500/close/open\r\n")));
+   BOOST_REQUIRE_EQUAL(request_.type, darner::request::RT_GET);
+   BOOST_REQUIRE_EQUAL(request_.queue, "foo+meow");
+   BOOST_REQUIRE(request_.get_open);
+   BOOST_REQUIRE(request_.get_close);
+   BOOST_REQUIRE(!request_.get_abort);
+   BOOST_REQUIRE_EQUAL(request_.wait_ms, 500);
+}
+
+// test that reparsing clears fields that were previously set
+BOOST_FIXTURE_TEST_CASE( test_reparse, fixtures::basic_request )
+{
+   BOOST_REQUIRE(grammar_.parse(string("GET foo+meow/t=500/close/open\r\n")));
+   BOOST_REQUIRE_EQUAL(request_.wait_ms, 500);
+   BOOST_REQUIRE(grammar_.parse(string("STATS\r\n")));
+   BOOST_REQUIRE_EQUAL(request_.wait_ms, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`request_grammar` parses requests for the commands and options that darner will support.

This implementation relies heavily on semantic actions on matches.  I tried to use the attribute stuff instead, to bind directly to a class, or just use `boost::fusion`, but the fact that the grammar branches at the beginning (if it's `GET` fill in these fields, if it's `SET` fill in these fields...) made that approach seem awkward.

Let me know if there's a better way to do it.
