### PR TITLE
Clean streams

### DIFF
--- a/include/darner/queue/iqstream.h
+++ b/include/darner/queue/iqstream.h
@@ -1,7 +1,7 @@
 #ifndef __DARNER_QUEUE_IQSTREAM_H__
 #define __DARNER_QUEUE_IQSTREAM_H__
 
-#include <boost/optional.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include "darner/queue/queue.h"
 
@@ -12,20 +12,25 @@ class iqstream
 public:
 
    /*
-    * tries to open an item immediately.  reads will fail if it couldn't open an item.
+    * destroying an open iqstream will close it with erase = false
     */
-   iqstream(queue& _queue);
+   ~iqstream();
 
    /*
-    * on the first read, tries to fetch an item and returns true if one was available
+    * tries to open an item for reading.  returns true if an item was available.
+    */
+   bool open(boost::shared_ptr<queue> queue);
+
+   /*
+    * reads a chunk
     * can continue calling read until eof (until tell() == size()).
     */
-   bool read(std::string& result);
+   void read(std::string& result);
 
    /*
-    * closes the iqstream.  if remove, completes the pop of the item off the queue, otherwise returns it
+    * closes the iqstream.  if erase, completes the pop of the item off the queue, otherwise returns it.
     */
-   void close(bool remove);
+   void close(bool erase);
 
    /*
     * returns the position in the stream in bytes.  only valid after first read()
@@ -35,14 +40,14 @@ public:
    /*
     * returns the size of the item.  only valid after first read()
     */
-    queue::size_type size() const { return header_ ? header_->size : tell_; }
+    queue::size_type size() const { return header_.size; }
    
 private:
 
-   queue& queue_;
+   boost::shared_ptr<queue> queue_;
 
-   boost::optional<queue::id_type> id_; // id of key in queue, only set after a succesful first read
-   boost::optional<queue::header_type> header_; // only set if it's multi-chunk
+   queue::id_type id_; // id of key in queue, only valid if open() succeeded
+   queue::header_type header_; // only valid if it's multi-chunk
    queue::size_type chunk_pos_;
    queue::size_type tell_;
 };

--- a/include/darner/queue/iqstream.h
+++ b/include/darner/queue/iqstream.h
@@ -40,7 +40,12 @@ public:
    /*
     * returns the size of the item.  only valid after first read()
     */
-    queue::size_type size() const { return header_.size; }
+   queue::size_type size() const { return header_.size; }
+
+   /*
+    * returns true if open
+    */
+   operator bool() const { return queue_; }
    
 private:
 

--- a/include/darner/queue/oqstream.h
+++ b/include/darner/queue/oqstream.h
@@ -1,8 +1,7 @@
 #ifndef __DARNER_QUEUE_OQSTREAM_H__
 #define __DARNER_QUEUE_OQSTREAM_H__
 
-#include <boost/optional.hpp>
-#include <boost/function.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include "darner/queue/queue.h"
 
@@ -12,32 +11,39 @@ class oqstream
 {
 public:
 
-   oqstream(queue& _queue, queue::size_type chunks);
+   /*
+    * destroying an unfinished oqstream will cancel it
+    */
+   ~oqstream();
+
+   /*
+    * immediately opens an oqstream for writing.  the stream will automatically close after chunks_count chunks
+    * have been written
+    */
+   void open(boost::shared_ptr<queue> queue, queue::size_type chunks_count);
 
    /*
     * writes a chunk of the item. fails if more chunks are written than originally reserved.
     */
-   void write(const std::string& value);
+   void write(const std::string& chunk);
 
    /*
-    * cancels the oqstream write.  only available to mutli-chunks that haven't written all their chunks yet.
+    * cancels the oqstream write.  only available if the stream hasn't written chunks_count chunks yet
     */
    void cancel();
 
    /*
     * returns the position in the stream in bytes.
     */
-   queue::size_type tell() const { return tell_; }
+   queue::size_type tell() const { return header_.size; }
    
 private:
 
-   queue& queue_;
-   queue::size_type chunks_;
+   boost::shared_ptr<queue> queue_;
 
-   boost::optional<queue::id_type> id_; // id of key in queue, only set after all chunks are written
-   boost::optional<queue::header_type> header_; // only set if it's multi-chunk
+   queue::id_type id_; // id of key in queue, only set after all chunks are written
+   queue::header_type header_; // only set if it's multi-chunk
    queue::size_type chunk_pos_;
-   queue::size_type tell_;
 };
 
 } // darner

--- a/include/darner/util/queue_map.hpp
+++ b/include/darner/util/queue_map.hpp
@@ -2,9 +2,10 @@
 #define __DARNER_QUEUE_MAP_HPP__
 
 #include <string>
+#include <map>
 
 #include <boost/asio.hpp>
-#include <boost/ptr_container/ptr_map.hpp>
+#include <boost/shared_ptr.hpp>
 #include <boost/filesystem/operations.hpp>
 
 #include "darner/queue/queue.h"
@@ -14,10 +15,14 @@ namespace darner {
 // maps a queue name to a queue instance, reloads queues
 class queue_map
 {
+private:
+
+   typedef std::map<std::string, boost::shared_ptr<queue> > container_type;
+
 public:
 
-   typedef boost::ptr_map<std::string, queue>::iterator iterator;
-   typedef boost::ptr_map<std::string, queue>::const_iterator const_iterator;
+   typedef std::map<std::string, boost::shared_ptr<queue> >::iterator iterator;
+   typedef std::map<std::string, boost::shared_ptr<queue> >::const_iterator const_iterator;
 
    queue_map(boost::asio::io_service& ios, const std::string& data_path)
    : data_path_(data_path), ios_(ios)
@@ -26,19 +31,22 @@ public:
       for (boost::filesystem::directory_iterator it(data_path_); it != end_it; ++it)
       {
          std::string queue_name = it->path().leaf().string();
-         queues_.insert(queue_name, new queue(ios_, it->path().string()));
+         boost::shared_ptr<queue> p(new queue(ios_, (data_path_ / queue_name).string()));
+         queues_.insert(container_type::value_type(queue_name, p));
       }
    }
 
-   queue& operator[] (const std::string& queue_name)
+   boost::shared_ptr<queue> operator[] (const std::string& queue_name)
    {
-      boost::ptr_map<std::string, queue>::iterator it = queues_.find(queue_name);
+      iterator it = queues_.find(queue_name);
+
       if (it == queues_.end())
       {
-         std::string q(queue_name); // some strange ptr_map limitation, needs non-const key
-         it = queues_.insert(q, new queue(ios_, (data_path_ / queue_name).string())).first;
+         boost::shared_ptr<queue> p(new queue(ios_, (data_path_ / queue_name).string()));
+         it = queues_.insert(container_type::value_type(queue_name, p)).first;
       }
-      return *it->second;
+
+      return it->second;
    }
 
    iterator begin()             { return queues_.begin(); }
@@ -48,7 +56,7 @@ public:
 
 private:
 
-   boost::ptr_map<std::string, queue> queues_;
+   std::map<std::string, boost::shared_ptr<queue> > queues_;
 
    boost::filesystem::path data_path_;
    boost::asio::io_service& ios_;

--- a/include/darner/util/queue_map.hpp
+++ b/include/darner/util/queue_map.hpp
@@ -21,8 +21,8 @@ private:
 
 public:
 
-   typedef std::map<std::string, boost::shared_ptr<queue> >::iterator iterator;
-   typedef std::map<std::string, boost::shared_ptr<queue> >::const_iterator const_iterator;
+   typedef container_type::iterator iterator;
+   typedef container_type::const_iterator const_iterator;
 
    queue_map(boost::asio::io_service& ios, const std::string& data_path)
    : data_path_(data_path), ios_(ios)

--- a/src/net/handler.cpp
+++ b/src/net/handler.cpp
@@ -1,6 +1,5 @@
 #include "darner/net/handler.h"
 
-#include <sstream>
 #include <boost/array.hpp>
 
 using namespace std;
@@ -38,31 +37,24 @@ void handler::start()
 void handler::read_request(const system::error_code& e, size_t bytes_transferred)
 {
    if (e)
-   {
-      log::ERROR("handler<%1%>::read_request: %2%", shared_from_this(), e.message());
-      return done(false);
-   }
+      return error("read_request", e);
 
-   async_read_until(
-      socket_, in_, '\n',
-      bind(&handler::parse_request, shared_from_this(), _1, _2));
+   async_read_until(socket_, in_, '\n', bind(&handler::parse_request, shared_from_this(), _1, _2));
 }
 
 void handler::parse_request(const system::error_code& e, size_t bytes_transferred)
 {
-   if (e)
-   {
-      if (e != error::eof || in_.size()) // clean close by client?
-         log::ERROR("handler<%1%>::handle_read_request: %2%", shared_from_this(), e.message());
-      return done(false);
-   }
+   if (e == error::eof && !in_.size()) // clean close by client?
+      return;
+   else if (e)
+      return error("parse_request", e);
 
    // TODO: it would have been nice to pass in an buffers_iterator directly to spirit, but
    // something constness thing about the iterator_traits::value_type is borking up being able to use it
    asio::streambuf::const_buffers_type bufs = in_.data();
    buf_.assign(buffers_begin(bufs), buffers_begin(bufs) + bytes_transferred);
    if (!parser_.parse(req_, buf_))
-      return done(false, "ERROR\r\n");
+      return error("");
    in_.consume(bytes_transferred);
 
    switch (req_.type)
@@ -71,8 +63,8 @@ void handler::parse_request(const system::error_code& e, size_t bytes_transferre
    case request::RT_VERSION:   write_version(); break;
    case request::RT_FLUSH:     flush();         break;
    case request::RT_FLUSH_ALL: flush_all();     break;
-   case request::RT_SET:       set();           break;
-   case request::RT_GET:       get();           break;
+   case request::RT_SET:       ++stats_.cmd_sets; set(); break;
+   case request::RT_GET:       ++stats_.cmd_gets; get(); break;
    }
 }
 
@@ -92,7 +84,8 @@ void handler::write_stats()
 
 void handler::write_version()
 {
-   done(true, "VERSION " + string(DARNER_VERSION) + "\r\n");
+   buf_ = "VERSION " + string(DARNER_VERSION) + "\r\n";
+   async_write(socket_, buffer(buf_), bind(&handler::read_request, shared_from_this(), _1, _2));
 }
 
 void handler::flush()
@@ -107,11 +100,9 @@ void handler::flush_all()
 
 void handler::set()
 {
-   ++stats_.cmd_sets;
-
    // round up the number of chunks we need, and fetch \r\n if it's just one chunk
-   push_stream_ = in_place(ref(queues_[req_.queue]), (req_.num_bytes + chunk_size_ - 1) / chunk_size_);
-   queue::size_type remaining = req_.num_bytes - push_stream_->tell();
+   push_stream_.open(queues_[req_.queue], (req_.num_bytes + chunk_size_ - 1) / chunk_size_);
+   queue::size_type remaining = req_.num_bytes - push_stream_.tell();
    queue::size_type required = remaining > chunk_size_ ? chunk_size_ : remaining + 2;
 
    async_read(
@@ -122,19 +113,16 @@ void handler::set()
 void handler::set_on_read_chunk(const system::error_code& e, size_t bytes_transferred)
 {
    if (e)
-   {
-      log::ERROR("handler<%1%>::set_on_read_chunk: %2%", shared_from_this(), e.message());
-      return done(false);
-   }
+      return error("set_on_read_chunk", e);
 
    asio::streambuf::const_buffers_type bufs = in_.data();
-   queue::size_type bytes_remaining = req_.num_bytes - push_stream_->tell();
+   queue::size_type bytes_remaining = req_.num_bytes - push_stream_.tell();
 
    if (bytes_remaining <= chunk_size_) // last chunk!  make sure it ends with \r\n
    {
       buf_.assign(buffers_begin(bufs) + bytes_remaining, buffers_begin(bufs) + bytes_remaining + 2);
       if (buf_ != "\r\n")
-         return done(false, "CLIENT_ERROR bad data chunk\r\n");
+         return error("bad data chunk", "CLIENT_ERROR");
       buf_.assign(buffers_begin(bufs), buffers_begin(bufs) + bytes_remaining);
       in_.consume(bytes_remaining + 2);
    }
@@ -146,23 +134,21 @@ void handler::set_on_read_chunk(const system::error_code& e, size_t bytes_transf
 
    try
    {
-      push_stream_->write(buf_);
+      push_stream_.write(buf_);
    }
    catch (const system::system_error& ex)
    {
-      log::ERROR("handler<%1%>::set_on_write_chunk: %2%", shared_from_this(), ex.code().message());
-      return done(false, "SERVER_ERROR " + ex.code().message() + "\r\n");
+      return error("set_on_read_chunk", ex);
    }
 
-   if (push_stream_->tell() == req_.num_bytes) // are we all done?
+   if (push_stream_.tell() == req_.num_bytes) // are we all done?
    {
-      push_stream_.reset();
       ++stats_.items_enqueued;
-      return done(true, "STORED\r\n");
+      return end("STORED\r\n");
    }
 
    // otherwise, second verse, same as the first
-   queue::size_type remaining = req_.num_bytes - push_stream_->tell();
+   queue::size_type remaining = req_.num_bytes - push_stream_.tell();
    queue::size_type required = remaining > chunk_size_ ? chunk_size_ : remaining + 2;
    async_read(
       socket_, in_, transfer_at_least(required > in_.size() ? required - in_.size() : 0),
@@ -171,80 +157,60 @@ void handler::set_on_read_chunk(const system::error_code& e, size_t bytes_transf
 
 void handler::get()
 {
-   ++stats_.cmd_gets;
-
    if (req_.get_abort && (req_.get_open || req_.get_close))
-      return done(false, "CLIENT_ERROR abort must be by itself\r\n");
+      return error("abort must be by itself", "CLIENT_ERROR");
 
-   if (pop_stream_) // before getting the next item, close this one
+   if (req_.get_abort || req_.get_close)
    {
-      if (!req_.get_close && !req_.get_abort) // needs to be a close or an abort
-         return done(false, "CLIENT_ERROR close current item first\r\n");
-
       try
       {
-         pop_stream_->close(req_.get_close);
+         pop_stream_.close(req_.get_close);
       }
       catch (const system::system_error& ex)
       {
-         log::ERROR("handler<%1%>::get: %2%", shared_from_this(), ex.code().message());
-         return done(false, "SERVER_ERROR " + ex.code().message() + "\r\n");
+         return error("get", ex);
       }
-
-      pop_stream_.reset();
    }
+   else if (pop_stream_)
+      return error("close current item first", "CLIENT_ERROR");
 
    if (req_.get_abort)
-      return done(true, "END\r\n"); // aborts go no further
+      return end(); // aborts go no further
 
-   pop_stream_ = in_place(ref(queues_[req_.queue]));
-
-   if (!pop_stream_->read(buf_))
+   if (!pop_stream_.open(queues_[req_.queue]))
    {
-      // couldn't read... can we at least wait?
-      if (req_.wait_ms)
-         queues_[req_.queue].wait(req_.wait_ms, bind(&handler::get_on_queue_return, shared_from_this(), _1));
+      if (req_.wait_ms) // couldn't read... can we at least wait?
+         queues_[req_.queue]->wait(req_.wait_ms, bind(&handler::get_on_queue_return, shared_from_this(), _1));
       else
-      {
-         pop_stream_.reset();
-         return done(true, "END\r\n");
-      }
+         return end();
    }
-   else
-      write_first_chunk();
+
+   try
+   {
+      pop_stream_.read(buf_);
+   }
+   catch (const system::system_error& ex)
+   {
+      return error("get", ex);
+   }
+
+   write_first_chunk();
 }
 
 void handler::get_on_queue_return(const boost::system::error_code& e)
 {
    if (e == asio::error::timed_out)
-   {
-      pop_stream_.reset();
-      return done(true, "END\r\n");
-   }
+      return end();
    else if (e)
-   {
-      pop_stream_.reset();
-      log::ERROR("handler<%1%>::get_on_queue_return: %2%", shared_from_this(), e.message());
-      return done(false, "SERVER_ERROR " + e.message() + "\r\n");
-   }
+      return error("get_on_queue_return", e);
    else
-   {
-      if (!pop_stream_->read(buf_))
-      {
-         // well this is very unusual.  the queue woke us up but nothing is available.
-         pop_stream_.reset();
-         log::ERROR("handler<%1%>::get_on_queue_return: %2%", shared_from_this(), "bad queue_return");
-         return done(false, "SERVER_ERROR bad queue return\r\n");
-      }
-
-      write_first_chunk();
-   }
+      get();
 }
 
 void handler::write_first_chunk()
 {
    ostringstream oss;
-   oss << "VALUE " << req_.queue << " 0 " << pop_stream_->size() << "\r\n";
+   oss << "VALUE " << req_.queue << " 0 " << pop_stream_.size() << "\r\n";
    header_buf_ = oss.str();
    array<const_buffer, 2> bufs = {{ buffer(header_buf_), buffer(buf_) }};
 
@@ -254,86 +220,36 @@ void handler::write_first_chunk()
 void handler::get_on_write_chunk(const boost::system::error_code& e, size_t bytes_transferred)
 {
    if (e)
-   {
-      log::ERROR("handler<%1%>::get_on_write_chunk: %2%", shared_from_this(), e.message());
-      return done(false);
-   }
+      return error("get_on_write_chunk", e, false);
 
-   if (pop_stream_->tell() == pop_stream_->size())
+   if (pop_stream_.tell() == pop_stream_.size())
    {
       if (!req_.get_open)
       {
          try
          {
-            pop_stream_->close(true);
+            pop_stream_.close(true);
          }
          catch (const system::system_error& ex)
          {
-            log::ERROR("handler<%1%>::get_on_write_chunk: %2%", shared_from_this(), ex.code().message());
-            return done(false);
+            return error("get_on_write_chunk", ex, false);
          }
-         pop_stream_.reset();
       }
       ++stats_.items_dequeued;
-      return done(true, "\r\nEND\r\n");
+
+      return end("\r\nEND\r\n");
    }
    else
    {
       try
       {
-         pop_stream_->read(buf_);
+         pop_stream_.read(buf_);
       }
       catch (const system::system_error& ex)
       {
-         log::ERROR("handler<%1%>::get_on_write_chunk: %2%", shared_from_this(), ex.code().message());
-         return done(false);
+         return error("get_on_write_chunk", ex, false);
       }
+
       async_write(socket_, buffer(buf_), bind(&handler::get_on_write_chunk, shared_from_this(), _1, _2));
-   }
-}
-
-void handler::done(bool success, const std::string& msg /* = "" */)
-{
-   if (!msg.empty())
-   {
-      buf_ = msg;
-      if (success)
-         async_write(socket_, buffer(buf_), bind(&handler::read_request, shared_from_this(), _1, _2));
-      else
-         async_write(socket_, buffer(buf_), bind(&handler::finalize, shared_from_this(), _1, _2));
-   }
-   else
-   {
-      if (success)
-         read_request(system::error_code(), 0);
-      else
-         finalize(system::error_code(), 0);
-   }
-}
-
-void handler::finalize(const system::error_code& e, size_t bytes_transferred)
-{
-   if (pop_stream_)
-   {
-      try
-      {
-         pop_stream_->close(false);
-      }
-      catch (const system::system_error& ex)
-      {
-         log::ERROR("handler<%1%>::finalize: %2%", shared_from_this(), ex.code().message());
-      }
-   }
-
-   if (push_stream_)
-   {
-      try
-      {
-         push_stream_->cancel();
-      }
-      catch (const system::system_error& ex)
-      {
-         log::ERROR("handler<%1%>::finalize: %2%", shared_from_this(), ex.code().message());
-      }
    }
 }

--- a/src/net/handler.cpp
+++ b/src/net/handler.cpp
@@ -84,7 +84,7 @@ void handler::write_stats()
 
 void handler::write_version()
 {
-   buf_ = "VERSION " + string(DARNER_VERSION) + "\r\n";
+   buf_ = "VERSION " DARNER_VERSION "\r\n";
    async_write(socket_, buffer(buf_), bind(&handler::read_request, shared_from_this(), _1, _2));
 }
 

--- a/src/queue/iqstream.cpp
+++ b/src/queue/iqstream.cpp
@@ -1,54 +1,56 @@
 #include "darner/queue/iqstream.h"
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
-
-#include <leveldb/write_batch.h>
 
 using namespace std;
 using namespace boost;
 using namespace darner;
 
-iqstream::iqstream(queue& _queue)
-: queue_(_queue),
-  chunk_pos_(0),
-  tell_(0)
+iqstream::~iqstream()
 {
+   if (queue_)
+      queue_->pop_end(false, id_, header_);
 }
 
-bool iqstream::read(string& result)
+bool iqstream::open(shared_ptr<queue> queue)
 {
-   if (!id_) // should we try to fetch a queue item?
-   {
-      if (!queue_.pop_open(id_, header_, result))
-         return false;
+   if (queue_)
+      throw system::system_error(asio::error::already_open); // can't open what's open
 
-      if (!header_) // not multi-chunk?  we're done!
-      {
-         tell_ += result.size();
-         return true;
-      }
+   if (!queue->pop_begin(id_))
+      return false;
 
-      chunk_pos_ = header_->beg;
-   }
-
-   // if we have an id already, and are still requesting more reads, we must be multi-chunk
-   // make sure that's the cast, and that we haven't read past the end
-   if (!header_ || chunk_pos_ >= header_->end)
-      throw system::system_error(asio::error::eof);
-
-   queue_.read_chunk(result, chunk_pos_);
-
-   ++chunk_pos_;
-   tell_ += result.size();
+   queue_ = queue;
+   header_ = queue::header_type();
+   chunk_pos_ = header_.beg;
 
    return true;
 }
 
-void iqstream::close(bool remove)
+void iqstream::read(string& result)
 {
-   if (!id_)
-      throw system::system_error(asio::error::not_found); // can't close something we haven't opened
+   // not open or already read past end
+   if (!queue_ || chunk_pos_ >= header_.end)
+      throw system::system_error(asio::error::eof);
 
-   queue_.pop_close(remove, *id_, header_);
+   if (!chunk_pos_) // first read?  check if there's a header
+   {
+      queue_->pop_read(result, header_, id_);
+      chunk_pos_ = header_.beg;
+   }
+
+   if (header_.end > 1) // multi-chunk?  get the next chunk!
+      queue_->read_chunk(result, chunk_pos_);
+
+   ++chunk_pos_;
+   tell_ += result.size();
+}
+
+void iqstream::close(bool erase)
+{
+   if (!queue_)
+      throw system::system_error(asio::error::eof); // can't close something we haven't opened
+
+   queue_->pop_end(erase, id_, header_);
+   queue_.reset();
 }

--- a/tests/fixtures/basic_queue.hpp
+++ b/tests/fixtures/basic_queue.hpp
@@ -18,7 +18,7 @@ class basic_queue
 public:
 
    basic_queue()
-   : success_cb_(boost::bind(&basic_queue::success_cb, this, _1)),
+   : wait_cb_(boost::bind(&basic_queue::wait_cb, this, _1)),
      tmp_(boost::filesystem::temp_directory_path() / boost::filesystem::unique_path())
    {
       boost::filesystem::create_directories(tmp_);
@@ -33,12 +33,14 @@ public:
 
    void delayed_push(std::string& value, const boost::system::error_code& error)
    {
-      darner::oqstream(*queue_, 1).write(value);
+      darner::oqstream oqs;
+      oqs.open(queue_, 1);
+      oqs.write(value);
    }
 
 protected:
 
-   void success_cb(const boost::system::error_code& error)
+   void wait_cb(const boost::system::error_code& error)
    {
       error_ = error;
    }
@@ -46,10 +48,12 @@ protected:
    std::string pop_value_;
 
    boost::system::error_code error_;
-   darner::queue::success_callback success_cb_;
+   darner::queue::wait_callback wait_cb_;
 
    boost::asio::io_service ios_;
    boost::shared_ptr<darner::queue> queue_;
+   darner::oqstream oqs_;
+   darner::iqstream iqs_;
    boost::filesystem::path tmp_;
 };
 


### PR DESCRIPTION
@nova77 after reviewing the code I agree that boost::optional isn't really working.  It was forcing me to explicitly call `reset()` all over the handler.  Instead I've changed the stream classes to have a more explicit opened/closed state, and when streams are destroyed the naturally close.  This fits better with the model that when a conn hangs up, the dtor cleans up.

I also cleaned up some nomenclature and some of the comments in the queue class.
