### PR TITLE
quick compact: compact only evicted range when it reaches 32MB

### DIFF
--- a/include/darner/queue/queue.h
+++ b/include/darner/queue/queue.h
@@ -151,7 +151,18 @@ private:
 
       leveldb::Slice slice() const;
 
-      int compare(const key_type& other) const;
+      int compare(const key_type& other) const
+      {
+         if (type < other.type)
+            return -1;
+         else if (type > other.type)
+            return 1;
+         else if (id < other.id)
+            return -1;
+         else if (id > other.id)
+            return 1;
+         return 0;
+      }
 
       unsigned char type;
       id_type id;
@@ -193,6 +204,9 @@ private:
    // fires either if timer times out or is canceled
    void waiter_wakeup(const boost::system::error_code& e, boost::ptr_list<waiter>::iterator waiter_it);
 
+   // compact the underlying journal, discarding deleted items
+   void compact();
+
    // some leveldb sugar:
 
    void put(const key_type& key, const std::string& value)
@@ -230,6 +244,7 @@ private:
    key_type chunks_head_;
 
    size_type items_open_; // an open item is < TAIL but not in returned_
+   size_type bytes_evicted_; // after we've evicted 32MB from the journal, compress that evicted range
 
    std::set<id_type> returned_; // items < TAIL that were reserved but later returned (not popped)
 
@@ -237,6 +252,7 @@ private:
    boost::ptr_list<waiter>::iterator wake_up_it_;
 
    boost::asio::io_service& ios_;
+   const std::string path_;
 };
 
 } // darner


### PR DESCRIPTION
When darner pops an item, it writes a deletion marker to its journal.  Occasionally, it should sweep through the journal and delete the old items and the deletion markers.

The old approach had two problems:
- Old Darner compacted every 1024 pops, which meant the actual compaction range varied widely depending on item size.  With really large items (hundreds of kilobytes to megabytes) going through the queue, compaction happened infrequently, caused unbounded memory bloat, and was expensive, freezing the world for tens of seconds, when it did.
- Old Darner swept the whole journal instead of just the evicted range.  Sweeping just the known evicted range is much more efficient than trying to compact the whole journal.

This new compaction approach is more carefully amortized into regular operation: compactions will be upper bounded by how quickly the machine can sweep through 32MB of ram: in tests this is typically hundreds of milliseconds.

Many other queues do compaction in a separate thread - I've amortized it into regular operation because I don't want to deal with the extra complexity.  But I may consider that in the future.
