### PR TITLE
Add support for GETS

### DIFF
--- a/src/net/request.cpp
+++ b/src/net/request.cpp
@@ -44,7 +44,7 @@ request_grammar::request_grammar()
          >> qi::uint_  [phoenix::ref(req.wait_ms) = qi::_1]
         );
 
-   get = lit("get ")   [phoenix::ref(req.type) = request::RT_GET]
+   get = (lit("get ")|lit("gets "))   [phoenix::ref(req.type) = request::RT_GET]
       >> key_name      [phoenix::ref(req.queue) = qi::_1]
       >> *get_option;
 

--- a/tests/request.cpp
+++ b/tests/request.cpp
@@ -46,6 +46,18 @@ BOOST_FIXTURE_TEST_CASE( test_get, fixtures::basic_request )
    BOOST_REQUIRE_EQUAL(request_.wait_ms, 500);
 }
 
+// test that we get some options correctly for a gets
+BOOST_FIXTURE_TEST_CASE( test_gets, fixtures::basic_request )
+{
+   BOOST_REQUIRE(parser_.parse(request_, string("gets bar+woof/t=700/close/open\r\n")));
+   BOOST_REQUIRE_EQUAL(request_.type, darner::request::RT_GET);
+   BOOST_REQUIRE_EQUAL(request_.queue, "bar+woof");
+   BOOST_REQUIRE(request_.get_open);
+   BOOST_REQUIRE(request_.get_close);
+   BOOST_REQUIRE(!request_.get_abort);
+   BOOST_REQUIRE_EQUAL(request_.wait_ms, 700);
+}
+
 // test that reparsing clears fields that were previously set
 BOOST_FIXTURE_TEST_CASE( test_reparse, fixtures::basic_request )
 {


### PR DESCRIPTION
Small change to add support for the "gets" alias of "get" commands, with test.

Equivalent to the change that went into kestrel recently (https://github.com/robey/kestrel/commit/d1c93cbcf7f24161f489b779e21680e4fecb52dc)
