### PR TITLE
Updates to compile on debian/stretch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,11 @@ ADD_EXECUTABLE(test
                tests/main
                )
 
-FIND_PACKAGE(Boost 1.40.0 COMPONENTS thread system program_options unit_test_framework filesystem)
+FIND_PACKAGE(Boost 1.40.0 COMPONENTS thread system program_options filesystem unit_test_framework)
 
-TARGET_LINK_LIBRARIES(darner pthread ${Boost_LIBRARIES} leveldb snappy)
+# Explicitly list libraries for each Boost component to avoid linking server executable to the unit test library
+TARGET_LINK_LIBRARIES(darner pthread ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} leveldb snappy)
+
 TARGET_LINK_LIBRARIES(db ${Boost_LIBRARIES})
 TARGET_LINK_LIBRARIES(test pthread ${Boost_LIBRARIES} leveldb snappy)
 

--- a/bench/db.cpp
+++ b/bench/db.cpp
@@ -55,7 +55,7 @@ class session : public enable_shared_from_this<session>
 public:
 
    typedef ip::tcp::socket socket_type;
-   typedef shared_ptr<session> ptr_type;
+   typedef boost::shared_ptr<session> ptr_type;
 
    session(io_service& ios, results& _results, const string& host, size_t port, size_t bad_client_rate,
       size_t action = 0)

--- a/bench/db.cpp
+++ b/bench/db.cpp
@@ -50,7 +50,7 @@ struct results
    size_t sets_remaining;
 };
 
-class session : public enable_shared_from_this<session>
+class session : public boost::enable_shared_from_this<session>
 {
 public:
 

--- a/include/darner/queue/iqstream.h
+++ b/include/darner/queue/iqstream.h
@@ -45,7 +45,7 @@ public:
    /*
     * returns true if open
     */
-   operator bool() const { return queue_; }
+   operator bool() const { return static_cast<bool>(queue_); }
    
 private:
 

--- a/src/net/handler.cpp
+++ b/src/net/handler.cpp
@@ -228,12 +228,12 @@ void handler::get()
          }
       }
       ++stats_.items_dequeued;
-      array<const_buffer, 3> bufs = {{ buffer(header_buf_), buffer(buf_), buffer("\r\nEND\r\n", 7) }};
+      boost::array<const_buffer, 3> bufs = {{ buffer(header_buf_), buffer(buf_), buffer("\r\nEND\r\n", 7) }};
       async_write(socket_, bufs, bind(&handler::read_request, shared_from_this(), _1, _2));
    }
    else
    {
-      array<const_buffer, 2> bufs = {{ buffer(header_buf_), buffer(buf_) }};
+      boost::array<const_buffer, 2> bufs = {{ buffer(header_buf_), buffer(buf_) }};
       async_write(socket_, bufs, bind(&handler::get_on_write_chunk, shared_from_this(), _1, _2));
    }
 }

--- a/src/queue/iqstream.cpp
+++ b/src/queue/iqstream.cpp
@@ -12,7 +12,7 @@ iqstream::~iqstream()
       queue_->pop_end(false, id_, header_);
 }
 
-bool iqstream::open(shared_ptr<queue> queue)
+bool iqstream::open(boost::shared_ptr<queue> queue)
 {
    if (queue_)
       throw system::system_error(asio::error::already_open); // can't open what's open

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -40,7 +40,7 @@ BOOST_FIXTURE_TEST_CASE( test_pop_wait, fixtures::basic_queue )
                   "elevator sometimes, my 7 floor sanctuary";
    posix_time::ptime beg = boost::posix_time::microsec_clock::local_time();
    deadline_timer timer(ios_, posix_time::milliseconds(10));
-   timer.async_wait(bind(&fixtures::basic_queue::delayed_push, this, ref(value), _1));
+   timer.async_wait(bind(&fixtures::basic_queue::delayed_push, this, boost::ref(value), _1));
    queue_->wait(100, wait_cb_);
    ios_.run();
    boost::posix_time::ptime end = boost::posix_time::microsec_clock::local_time();
@@ -56,9 +56,9 @@ BOOST_FIXTURE_TEST_CASE( test_multiple_pop_wait, fixtures::basic_queue )
    string value2 = "Hotel robe got me feeling like a Sheik";
    posix_time::ptime beg = boost::posix_time::microsec_clock::local_time();
    deadline_timer timer1(ios_, posix_time::milliseconds(10));
-   timer1.async_wait(bind(&fixtures::basic_queue::delayed_push, this, ref(value1), _1));
+   timer1.async_wait(bind(&fixtures::basic_queue::delayed_push, this, boost::ref(value1), _1));
    deadline_timer timer2(ios_, posix_time::milliseconds(20));
-   timer2.async_wait(bind(&fixtures::basic_queue::delayed_push, this, ref(value2), _1));
+   timer2.async_wait(bind(&fixtures::basic_queue::delayed_push, this, boost::ref(value2), _1));
    queue_->wait(100, wait_cb_);
    queue_->wait(100, wait_cb_);
    ios_.run();
@@ -74,7 +74,7 @@ BOOST_FIXTURE_TEST_CASE( test_pop_wait_race, fixtures::basic_queue )
 {
    string value = "Fur pillows are hard to actually sleep on";
    deadline_timer timer(ios_, posix_time::milliseconds(80));
-   timer.async_wait(bind(&fixtures::basic_queue::delayed_push_block, this, ref(value), _1));
+   timer.async_wait(bind(&fixtures::basic_queue::delayed_push_block, this, boost::ref(value), _1));
    queue_->wait(100, wait_cb_);
    ios_.run();
 
@@ -86,7 +86,7 @@ BOOST_FIXTURE_TEST_CASE( test_pop_wait_timeout, fixtures::basic_queue )
 {
    string value = "Classical music is tight yo";
    deadline_timer timer(ios_, posix_time::milliseconds(50));
-   timer.async_wait(bind(&fixtures::basic_queue::delayed_push, this, ref(value), _1));
+   timer.async_wait(bind(&fixtures::basic_queue::delayed_push, this, boost::ref(value), _1));
    queue_->wait(10, wait_cb_);
    ios_.run();
 

--- a/tests/queue.cpp
+++ b/tests/queue.cpp
@@ -101,6 +101,7 @@ BOOST_FIXTURE_TEST_CASE( test_queue_close_reopen, fixtures::basic_queue )
 
    oqs_.open(queue_, 1);
    oqs_.write(value);
+   queue_.reset();
    queue_.reset(new darner::queue(ios_, (tmp_ / "queue").string()));
    BOOST_REQUIRE_EQUAL(queue_->count(), 1);
 


### PR DESCRIPTION
- Fixed ambiguous references with Boost v1.62 and libstdc++-6-dev as used in Debian 9 (Stretch)
- Added explicit type conversion to iqstream bool() operator
- Fixed checken-and-egg problem in test_queue_close_reopen unit test
- Tweaked CMake file to not link release binary against the unit test library
